### PR TITLE
id missing after insert() [h2]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.idea
 /target
 /*.iml
+mcve.mv.db

--- a/pom.xml
+++ b/pom.xml
@@ -1,131 +1,137 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.jooq.trial</groupId>
-    <artifactId>jooq-mcve</artifactId>
-    <version>1.0</version>
-    <name>jOOQ MCVE</name>
+  <groupId>org.jooq.trial</groupId>
+  <artifactId>jooq-mcve</artifactId>
+  <version>1.0</version>
+  <name>jOOQ MCVE</name>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <org.jooq.version>3.13.1</org.jooq.version>
-        <db.url>jdbc:h2:~/mcve</db.url>
-        <db.username>sa</db.username>
-        <db.password></db.password>
-    </properties>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <org.jooq.version>3.14.0</org.jooq.version>
+    <db.url>jdbc:h2:./mcve</db.url>
+    <db.username>sa</db.username>
+    <db.password></db.password>
+  </properties>
 
-    <dependencies>
+  <dependencies>
 
-        <!-- Database access -->
-        <dependency>
-            <groupId>org.jooq</groupId>
-            <artifactId>jooq</artifactId>
-            <version>${org.jooq.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <version>1.4.199</version>
-        </dependency>
+    <!-- Database access -->
+    <dependency>
+      <groupId>org.jooq</groupId>
+      <artifactId>jooq</artifactId>
+      <version>${org.jooq.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <version>1.4.199</version>
+    </dependency>
 
-        <!-- Logging -->
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.11.0</version>
-        </dependency>
+    <!-- Logging -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>2.11.0</version>
+    </dependency>
 
-        <!-- Testing -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
+    <!-- Testing -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>11</source>
-                    <target>11</target>
-                </configuration>
-            </plugin>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <source>11</source>
+          <target>11</target>
+        </configuration>
+      </plugin>
 
-            <plugin>
-                <groupId>org.flywaydb</groupId>
-                <artifactId>flyway-maven-plugin</artifactId>
-                <version>5.2.1</version>
-                <executions>
-                    <execution>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>migrate</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <url>${db.url}</url>
-                    <user>${db.username}</user>
-                    <password>${db.password}</password>
-                    <locations>
-                        <location>filesystem:src/main/resources/db/migration</location>
-                    </locations>
-                </configuration>
-            </plugin>
+      <plugin>
+        <groupId>org.flywaydb</groupId>
+        <artifactId>flyway-maven-plugin</artifactId>
+        <version>5.2.1</version>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>migrate</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <url>${db.url}</url>
+          <user>${db.username}</user>
+          <password>${db.password}</password>
+          <locations>
+            <location>filesystem:src/main/resources/db/migration</location>
+          </locations>
+        </configuration>
+      </plugin>
 
-            <plugin>
-                <groupId>org.jooq</groupId>
-                <artifactId>jooq-codegen-maven</artifactId>
-                <version>${org.jooq.version}</version>
+      <plugin>
+        <groupId>org.jooq</groupId>
+        <artifactId>jooq-codegen-maven</artifactId>
+        <version>${org.jooq.version}</version>
 
-                <executions>
-                    <execution>
-                        <id>default-cli</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>generate</goal>
-                        </goals>
+        <executions>
+          <execution>
+            <id>default-cli</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>generate</goal>
+            </goals>
 
-                        <configuration>
-                            <jdbc>
-                                <url>${db.url}</url>
-                                <user>${db.username}</user>
-                                <password>${db.password}</password>
-                            </jdbc>
-                            <generator>
-                                <database>
-                                    <includes>.*</includes>
-                                    <schemata>
-                                        <!-- PostgreSQL is lower case by default -->
-                                        <schema>
-                                            <inputSchema>mcve</inputSchema>
-                                        </schema>
+            <configuration>
+              <jdbc>
+                <url>${db.url}</url>
+                <user>${db.username}</user>
+                <password>${db.password}</password>
+              </jdbc>
+              <generator>
+                <database>
+                  <includes>.*</includes>
+                  <schemata>
+                    <!-- PostgreSQL is lower case by default -->
+                    <schema>
+                      <inputSchema>mcve</inputSchema>
+                    </schema>
 
-                                        <!-- H2 and others are upper case by default -->
-                                        <schema>
-                                            <inputSchema>MCVE</inputSchema>
-                                        </schema>
-                                    </schemata>
-                                </database>
-                                <generate>
-                                    <generatedAnnotation>false</generatedAnnotation>
-                                </generate>
-                                <target>
-                                    <packageName>org.jooq.mcve</packageName>
-                                    <directory>target/generated-sources/jooq-mcve</directory>
-                                </target>
-                            </generator>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+                    <!-- H2 and others are upper case by default -->
+                    <schema>
+                      <inputSchema>MCVE</inputSchema>
+                    </schema>
+                  </schemata>
+                  <forcedTypes>
+                    <forcedType>
+                      <name>INT</name>
+                      <includeTypes>BIGINT.*</includeTypes>
+                    </forcedType>
+                  </forcedTypes>
+                </database>
+                <generate>
+                  <generatedAnnotation>false</generatedAnnotation>
+                </generate>
+                <target>
+                  <packageName>org.jooq.mcve</packageName>
+                  <directory>target/generated-sources/jooq-mcve</directory>
+                </target>
+              </generator>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/src/main/resources/db/migration/V1__initialise_database.sql
+++ b/src/main/resources/db/migration/V1__initialise_database.sql
@@ -8,3 +8,10 @@ CREATE TABLE mcve.test (
   
   CONSTRAINT pk_test PRIMARY KEY (id) 
 );
+
+CREATE TABLE mcve.test_forced_type (
+  id    BIGINT NOT NULL AUTO_INCREMENT,
+  value INT,
+
+  CONSTRAINT pk_test_forced_type PRIMARY KEY (id)
+);

--- a/src/test/java/org/jooq/mcve/test/MCVETest.java
+++ b/src/test/java/org/jooq/mcve/test/MCVETest.java
@@ -38,7 +38,9 @@
 package org.jooq.mcve.test;
 
 import static org.jooq.mcve.Tables.TEST;
+import static org.jooq.mcve.Tables.TEST_FORCED_TYPE;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -53,32 +55,35 @@ import org.junit.Test;
 
 public class MCVETest {
 
-    Connection connection;
-    DSLContext ctx;
+  Connection connection;
+  DSLContext ctx;
 
-    @Before
-    public void setup() throws Exception {
-        connection = DriverManager.getConnection("jdbc:h2:~/mcve", "sa", "");
-        ctx = DSL.using(connection);
-    }
+  @Before
+  public void setup() throws Exception {
+    connection = DriverManager.getConnection("jdbc:h2:./mcve", "sa", "");
+    ctx = DSL.using(connection);
+  }
 
-    @After
-    public void after() throws Exception {
-        ctx = null;
-        connection.close();
-        connection = null;
-    }
+  @After
+  public void after() throws Exception {
+    ctx = null;
+    connection.close();
+    connection = null;
+  }
 
-    @Test
-    public void mcveTest() {
-        TestRecord result =
-        ctx.insertInto(TEST)
-           .columns(TEST.VALUE)
-           .values(42)
-           .returning(TEST.ID)
-           .fetchOne();
+  @Test
+  public void mcveTest() {
+    var record = ctx.newRecord(TEST);
+    record.setValue(42);
+    record.insert();
+    assertNotNull(record.getId());
+  }
 
-        result.refresh();
-        assertEquals(42, (int) result.getValue());
-    }
+  @Test
+  public void mcveTestForceType() {
+    var record = ctx.newRecord(TEST_FORCED_TYPE);
+    record.setValue(42);
+    record.insert();
+    assertNotNull(record.getId());
+  }
 }


### PR DESCRIPTION
Same as #5 but with h2 instead of mysql so simpler and faster (no test container).

With 3.13.x `id` is read after `insert()`. Generated `TestForcedType` record contains:
```java
@Override
public Identity<TestForcedTypeRecord, Integer> getIdentity() {
    return Keys.IDENTITY_TEST_FORCED_TYPE;
}
```

With 3.14.0 `id` is missing after `insert()`. Generated record contains:
```java
@Override
public Identity<TestForcedTypeRecord, Integer> getIdentity() {
    return (Identity<TestForcedTypeRecord, Integer>) super.getIdentity();
}
```

