### PR TITLE
MCVE for issue jOOQ/jOOQ#2288: character length semantics

### DIFF
--- a/jOOQ-mcve-java-oracle/src/main/java/org/jooq/mcve/java/oracle/tables/Test.java
+++ b/jOOQ-mcve-java-oracle/src/main/java/org/jooq/mcve/java/oracle/tables/Test.java
@@ -59,6 +59,11 @@ public class Test extends TableImpl<TestRecord> {
      */
     public final TableField<TestRecord, Integer> CD = createField(DSL.name("CD"), SQLDataType.INTEGER, this, "");
 
+    /**
+     * The column <code>MCVE.TEST.FOUR_CHARS</code>.
+     */
+    public final TableField<TestRecord, String> FOUR_CHARS = createField(DSL.name("FOUR_CHARS"), SQLDataType.VARCHAR(4), this, "");
+
     private Test(Name alias, Table<TestRecord> aliased) {
         this(alias, aliased, (Field<?>[]) null, null);
     }

--- a/jOOQ-mcve-java-oracle/src/main/java/org/jooq/mcve/java/oracle/tables/records/TestRecord.java
+++ b/jOOQ-mcve-java-oracle/src/main/java/org/jooq/mcve/java/oracle/tables/records/TestRecord.java
@@ -45,6 +45,20 @@ public class TestRecord extends UpdatableRecordImpl<TestRecord> {
         return (Integer) get(1);
     }
 
+    /**
+     * Setter for <code>MCVE.TEST.FOUR_CHARS</code>.
+     */
+    public void setFourChars(String value) {
+        set(2, value);
+    }
+
+    /**
+     * Getter for <code>MCVE.TEST.FOUR_CHARS</code>.
+     */
+    public String getFourChars() {
+        return (String) get(2);
+    }
+
     // -------------------------------------------------------------------------
     // Primary key information
     // -------------------------------------------------------------------------
@@ -68,11 +82,12 @@ public class TestRecord extends UpdatableRecordImpl<TestRecord> {
     /**
      * Create a detached, initialised TestRecord
      */
-    public TestRecord(Integer id, Integer cd) {
+    public TestRecord(Integer id, Integer cd, String fourChars) {
         super(Test.TEST);
 
         setId(id);
         setCd(cd);
+        setFourChars(fourChars);
         resetChangedOnNotNull();
     }
 }

--- a/jOOQ-mcve-java-oracle/src/main/resources/db/migration/init.sql
+++ b/jOOQ-mcve-java-oracle/src/main/resources/db/migration/init.sql
@@ -1,6 +1,7 @@
 CREATE TABLE mcve.test (
-  id NUMBER(7) GENERATED ALWAYS AS IDENTITY NOT NULL,
-  cd NUMBER(7),
+  id         NUMBER(7) GENERATED ALWAYS AS IDENTITY NOT NULL,
+  cd         NUMBER(7),
+  four_chars VARCHAR2(4 CHAR),
   
   CONSTRAINT pk_test PRIMARY KEY (id) 
 );

--- a/jOOQ-mcve-java-oracle/src/test/java/org/jooq/mcve/test/java/oracle/JavaTest.java
+++ b/jOOQ-mcve-java-oracle/src/test/java/org/jooq/mcve/test/java/oracle/JavaTest.java
@@ -1,10 +1,12 @@
 package org.jooq.mcve.test.java.oracle;
 
 import org.jooq.DSLContext;
+import org.jooq.JSON;
 import org.jooq.SQLDialect;
 import org.jooq.impl.DSL;
 import org.jooq.mcve.java.oracle.tables.records.TestRecord;
 import org.jooq.tools.JooqLogger;
+import org.jooq.tools.json.JSONObject;
 import org.junit.*;
 import org.testcontainers.containers.OracleContainer;
 import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
@@ -18,7 +20,9 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.Duration;
+import java.util.Map;
 
+import static org.jooq.impl.DSL.*;
 import static org.jooq.mcve.java.oracle.Tables.TEST;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -104,5 +108,38 @@ public class JavaTest {
 
         TestRecord record = ctx.fetchOne(TEST, TEST.CD.eq(42));
         assertNotNull(record.getId());
+    }
+
+    @Test
+    public void testCharacterSemantics() {
+
+        // the first of the following is null:
+        // select four_chars from dual cross apply json_table('{"FOUR_CHARS":"HØST"}','$' columns("FOUR_CHARS" varchar2(4)));
+        // select four_chars from dual cross apply json_table('{"FOUR_CHARS":"HØST"}','$' columns("FOUR_CHARS" varchar2(4 char)));
+
+        var expectedFourChars = "HØST";
+
+        var field = field(TEST.FOUR_CHARS.getName());
+        var name = name("jt", field.getName());
+        var fourCharsUserType = field(name, TEST.FOUR_CHARS.getType());      // type == varchar2(4000)
+        var fourCharsDataType = field(name, TEST.FOUR_CHARS.getDataType());  // type == varchar2(4)
+        var jsonObject = new JSONObject(Map.of(field.getName(), expectedFourChars));
+        JSON json = JSON.json(jsonObject.toString());
+
+        var userTypeRes = ctx.select(field)
+                .from("DUAL")
+                .crossApply(jsonTable(json, "$")
+                        .column(fourCharsUserType)
+                        .as("jt"))
+                .fetchAny(field.getName());
+        var dataTypeRes = ctx.select(field)
+                .from("DUAL")
+                .crossApply(jsonTable(json, "$")
+                        .column(fourCharsDataType)
+                        .as("jt"))
+                .fetchAny(field.getName());
+
+        assertEquals(expectedFourChars, userTypeRes);
+        assertEquals(expectedFourChars, dataTypeRes); // <-- fails! We cannot use Jooq's computed data type for invocations of json_table
     }
 }


### PR DESCRIPTION
jOOQ reads Oracle column definitions with character length semantics incorrectly, assuming byte length is used. The result is data types that misrepresent the database.

For the `json_table` function, the data type cannot be used.

jOOQ should have a better understanding of Oracle's VARCHAR columns, and `LengthType` seems like what is needed.