### PR TITLE
Add nix dev shell + r2dbc transactionPublisher cancel-leak MCVE

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@
 /target
 **/build
 /*.iml
+
+### Nix / direnv ###
+/.direnv
+/result
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782948114,
+        "narHash": "sha256-AXmz9ho4Lud5CsbrZsuSVwpQZ4o5FgZ1chxBn5cJ8+0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9e92285f211dad236540fd617d7e30e0b99bc0e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,74 @@
+{
+  description = "jOOQ MCVE development environment (JDK + Testcontainers/podman wiring)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    in
+    {
+      devShells = forAllSystems (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            config.allowUnfree = true;
+          };
+          isDarwin = pkgs.stdenv.isDarwin;
+
+          # Gradle 8.13 (see gradle/wrapper/gradle-wrapper.properties) runs on
+          # Java 8-23; jOOQ 3.21 needs Java 17+. JDK 21 (LTS) satisfies both and
+          # is the toolchain the codegen/tests build against.
+          jdk = pkgs.jdk21_headless;
+
+          nixPodman = "${pkgs.podman}/bin/podman";
+        in
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              jdk
+              git
+            ] ++ pkgs.lib.optionals (!isDarwin) [
+              # Container CLI (the daemon is system-level via podman). On macOS
+              # podman runs in a VM installed outside nix (`podman machine`).
+              podman
+            ];
+
+            env = {
+              JAVA_HOME = "${jdk}";
+              # Testcontainers' Ryuk resource-reaper is flaky under rootless
+              # podman (privileged socket-mount). The gradle tc-stop tasks clean
+              # up containers explicitly, so disable it. See
+              # https://java.testcontainers.org/features/configuration/
+              TESTCONTAINERS_RYUK_DISABLED = "true";
+            };
+
+            shellHook = ''
+              # Testcontainers talks to the container runtime via DOCKER_HOST.
+              # Point it at podman's socket only when podman's daemon is actually
+              # reachable; otherwise leave DOCKER_HOST alone so a running Docker
+              # Desktop / dockerd is used instead. We do NOT key off "docker is
+              # down" — Docker users often enter the shell before Docker starts,
+              # and exporting a dead podman socket would break their later
+              # `docker` calls.
+              if ${nixPodman} info >/dev/null 2>&1; then
+                ${if isDarwin
+                  then ''export DOCKER_HOST="unix://$HOME/.local/share/containers/podman/machine/podman.sock"''
+                  else ''export DOCKER_HOST="unix:///run/user/$(id -u)/podman/podman.sock"''
+                }
+                echo "jOOQ-mcve dev shell: DOCKER_HOST -> $DOCKER_HOST (podman)"
+              else
+                echo "jOOQ-mcve dev shell: podman not reachable, leaving DOCKER_HOST to docker default"
+                ${pkgs.lib.optionalString isDarwin ''echo "  (run 'podman machine start' to bring podman up)"''}
+              fi
+
+              echo "jOOQ-mcve dev shell loaded ($(java -version 2>&1 | head -1))"
+            '';
+          };
+        }
+      );
+    };
+}

--- a/jOOQ-mcve-java-r2dbc-txn-leak/.gitignore
+++ b/jOOQ-mcve-java-r2dbc-txn-leak/.gitignore
@@ -1,0 +1,6 @@
+/.classpath
+/.project
+/.settings
+/.idea
+/target
+/*.iml

--- a/jOOQ-mcve-java-r2dbc-txn-leak/README.md
+++ b/jOOQ-mcve-java-r2dbc-txn-leak/README.md
@@ -1,0 +1,81 @@
+# MCVE: `transactionPublisher` leaks an R2DBC connection when cancelled mid-`BEGIN`
+
+`DSLContext.transactionPublisher(...)` acquires a connection, runs `BEGIN`
+(via `Connection.beginTransaction()`), subscribes to the user publisher, then
+runs `COMMIT`/`ROLLBACK` + `Connection.close()` on a terminal signal.
+
+On **cancellation** of the outer subscription, jOOQ tears down **without**
+running the `ROLLBACK` + `close()` finalizer **if the cancel lands after `BEGIN`
+is issued but before the transaction body runs**. The connection stays checked
+out and `idle in transaction`, is never returned to the
+`io.r2dbc.pool.ConnectionPool`, and the pooled slot is lost forever. Under
+sustained cancellation traffic `acquiredSize()` climbs to `maxSize` and every
+further acquire fails with `R2dbcTimeoutException: Connection acquisition timed
+out`.
+
+## The cancellation window
+
+The leak needs the cancel to land while a round-trip **other than the user's
+statement** is in flight — specifically while the `BEGIN` round-trip is awaiting
+its response. Cancelling during an *active statement* (e.g. `SELECT pg_sleep(...)`)
+is a **different** window that jOOQ already handles (it rolls back + closes) —
+which is why this never reproduced on a fast/local DB and only showed up behind a
+higher-latency network path (an RDS Proxy in production).
+
+To hit the window deterministically this MCVE:
+
+1. Starts Postgres + Toxiproxy on a shared Testcontainers network.
+2. Builds an `io.r2dbc.pool.ConnectionPool` (`maxSize`/`initialSize` = 5,
+   `validationDepth = LOCAL` so acquire does no round-trip) over
+   `r2dbc-postgresql`, pointed at the **Toxiproxy** proxy port.
+3. **Warms the pool first** (`pool.warmup().block()`) so connections are
+   established before any latency exists.
+4. Adds a **300 ms downstream `latency` toxic** — now every round-trip,
+   including `BEGIN`, is delayed 300 ms.
+5. Runs N transactions, each cancelled ~80 ms in (`Disposable.dispose()` ==
+   Reactive Streams `Subscription.cancel()`), so the cancel lands inside the
+   delayed `BEGIN`.
+6. Sleeps 2 s (real time) to let any async release settle, then reads
+   `pool.getMetrics().get().acquiredSize()`.
+
+## Root-cause hypothesis / suggested fix
+
+jOOQ's transaction publisher appears to attach its cleanup
+(`ROLLBACK` + `Connection.close()`) to completion/error rather than to **all**
+terminal signals including **cancel**. Modelling the whole transaction as
+`Flux.usingWhen(acquire, use, commit, rollbackOnError, rollbackOnCancel)` —
+Reactor's `usingWhen` has a dedicated async cancel-cleanup path — would run the
+async `ROLLBACK` + `close` on cancellation too.
+
+## Tests
+
+| Test | Scenario | Asserts |
+|---|---|---|
+| `bug_cancelDuringBegin_leaksConnection` | cancel mid-`BEGIN` (300 ms latency, cancel @ 80 ms) | `acquiredSize() > 0` — **the leak** (a fix would make this 0) |
+| `control_runToCompletion_doesNotLeak` | same transaction, no cancel | `acquiredSize() == 0` |
+| `control_cancelDuringActiveStatement_doesNotLeak` | cancel during `pg_sleep(3)` | `acquiredSize() == 0` (jOOQ handles this window) |
+
+The bug test also prints the corroborating `pg_stat_activity` evidence — sessions
+with `application_name = 'r2dbc-postgresql'`, `state = 'idle in transaction'`,
+`query = 'BEGIN'` — read on a separate JDBC connection.
+
+> The bug test asserts the **buggy** behaviour (`acquiredSize() > 0`). If it
+> fails with `acquiredSize == 0`, the running jOOQ version has fixed the leak.
+
+## Versions
+
+- jOOQ `3.21.6` (this repo's version; the report confirmed `3.21.1` still repros)
+- `io.r2dbc:r2dbc-pool:1.0.2.RELEASE`, `org.postgresql:r2dbc-postgresql:1.0.7.RELEASE`
+- `io.projectreactor:reactor-core:3.6.11`
+- Postgres 17, Toxiproxy `ghcr.io/shopify/toxiproxy:2.9.0`
+- No Kotlin/coroutines — the cancellation is a plain Reactive Streams
+  `Subscription.cancel()`.
+
+## Running
+
+Needs a container runtime (Docker or podman). The repo's `flake.nix` dev shell
+wires `DOCKER_HOST` to podman and disables Testcontainers Ryuk.
+
+```bash
+./gradlew :jOOQ-mcve-java-r2dbc-txn-leak:test
+```

--- a/jOOQ-mcve-java-r2dbc-txn-leak/build.gradle.kts
+++ b/jOOQ-mcve-java-r2dbc-txn-leak/build.gradle.kts
@@ -1,0 +1,55 @@
+// MCVE: jOOQ transactionPublisher leaks an r2dbc connection when the
+// subscription is cancelled after BEGIN but before the transaction body runs.
+//
+// Unlike the other modules in this repo, this one does NOT run jOOQ code
+// generation. The reproducer talks to a `t(id int)` table via jOOQ's plain-SQL
+// DSL (DSL.table/DSL.field), so there is no build-time Testcontainers codegen
+// step and no generated sources.
+plugins {
+    id("java")
+}
+
+// Defaults to the repo's jOOQ version (inherited from the root build), but can
+// be overridden to reproduce against a specific release, e.g.
+//   ./gradlew :jOOQ-mcve-java-r2dbc-txn-leak:test -PjooqVersion=3.21.1
+val jooqVersion = (findProperty("jooqVersion") as String?) ?: version.toString()
+
+dependencies {
+    // jOOQ core (open source edition, Maven Central) — provides the reactive
+    // DSLContext.transactionPublisher(...) under test.
+    implementation("org.jooq:jooq:$jooqVersion")
+
+    // R2DBC: SPI + connection pool + the postgres driver.
+    implementation("io.r2dbc:r2dbc-spi:1.0.0.RELEASE")
+    implementation("io.r2dbc:r2dbc-pool:1.0.2.RELEASE")
+    implementation("org.postgresql:r2dbc-postgresql:1.0.7.RELEASE")
+
+    // Reactor — the cancellation is a plain Reactive Streams Subscription.cancel()
+    // driven via Disposable.dispose(). No Kotlin/coroutines needed.
+    implementation("io.projectreactor:reactor-core:3.6.11")
+
+    // Test harness: JUnit 4 (matches the sibling modules) + Testcontainers for
+    // Postgres and Toxiproxy (the latter injects the BEGIN round-trip latency
+    // that opens the cancellation window).
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.testcontainers:postgresql:1.21.4")
+    testImplementation("org.testcontainers:toxiproxy:1.21.4")
+
+    // Plain JDBC driver — used on a side connection to read pg_stat_activity
+    // (the corroborating "idle in transaction" evidence) and to CREATE TABLE t.
+    testImplementation("org.postgresql:postgresql:42.7.11")
+
+    // A slf4j binding so reactor/r2dbc/testcontainers logs are readable.
+    testRuntimeOnly("org.slf4j:slf4j-simple:2.0.13")
+}
+
+tasks.test {
+    // The reproducer pulls images, warms a pool, and uses real-time sleeps to
+    // let async release settle — give it room and stream its stdout.
+    testLogging {
+        showStandardStreams = true
+        events("passed", "skipped", "failed")
+    }
+    // Testcontainers reads DOCKER_HOST from the environment (the flake.nix dev
+    // shell points it at podman when podman is up); nothing to configure here.
+}

--- a/jOOQ-mcve-java-r2dbc-txn-leak/src/test/java/org/jooq/mcve/r2dbc/txnleak/TransactionPublisherCancelLeakTest.java
+++ b/jOOQ-mcve-java-r2dbc-txn-leak/src/test/java/org/jooq/mcve/r2dbc/txnleak/TransactionPublisherCancelLeakTest.java
@@ -1,0 +1,287 @@
+package org.jooq.mcve.r2dbc.txnleak;
+
+import eu.rekawek.toxiproxy.Proxy;
+import eu.rekawek.toxiproxy.ToxiproxyClient;
+import eu.rekawek.toxiproxy.model.ToxicDirection;
+import eu.rekawek.toxiproxy.model.toxic.Latency;
+import io.r2dbc.pool.ConnectionPool;
+import io.r2dbc.pool.ConnectionPoolConfiguration;
+import io.r2dbc.postgresql.PostgresqlConnectionConfiguration;
+import io.r2dbc.postgresql.PostgresqlConnectionFactory;
+import io.r2dbc.spi.ValidationDepth;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.SQLDialect;
+import org.jooq.Table;
+import org.jooq.impl.DSL;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.ToxiproxyContainer;
+import org.testcontainers.utility.DockerImageName;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * MCVE for the jOOQ {@code DSLContext.transactionPublisher(...)} cancellation
+ * leak.
+ *
+ * <p>When the outer subscription is cancelled <em>after</em> jOOQ has issued
+ * {@code BEGIN} (via {@code Connection.beginTransaction()}) but <em>before</em>
+ * the transaction body runs, jOOQ tears down without running its
+ * {@code ROLLBACK} + {@code Connection.close()} finalizer. The connection is
+ * left checked out and {@code idle in transaction}, is never returned to the
+ * {@link ConnectionPool}, and the pooled slot is lost permanently.
+ *
+ * <p>The window is only reachable when the {@code BEGIN} round-trip is slow
+ * enough for the cancel to land inside it. We make it deterministic by warming
+ * the pool first, then injecting a fixed downstream latency with Toxiproxy, and
+ * cancelling well before that latency elapses.
+ *
+ * <p>Structure:
+ * <ul>
+ *   <li>{@link #bug_cancelDuringBegin_leaksConnection()} — the leak. Asserts
+ *       {@code acquiredSize() > 0} (jOOQ's bug; the fixed behaviour would be 0).</li>
+ *   <li>{@link #control_runToCompletion_doesNotLeak()} — no cancel; asserts 0.</li>
+ *   <li>{@link #control_cancelDuringActiveStatement_doesNotLeak()} — cancel while
+ *       a {@code pg_sleep} statement is active; jOOQ handles this window, asserts 0.</li>
+ * </ul>
+ */
+public class TransactionPublisherCancelLeakTest {
+
+    // Toxiproxy image. Bump if this tag is ever unavailable in your registry.
+    private static final DockerImageName TOXIPROXY_IMAGE =
+        DockerImageName.parse("ghcr.io/shopify/toxiproxy:2.9.0");
+    private static final DockerImageName POSTGRES_IMAGE =
+        DockerImageName.parse("postgres:17");
+
+    // The first proxied port pre-exposed by ToxiproxyContainer.
+    private static final int TOXIPROXY_PROXY_PORT = 8666;
+
+    private static final int    POOL_SIZE       = 5;
+    private static final int    N_TRANSACTIONS  = 5;
+    private static final long   BEGIN_LATENCY_MS = 300; // injected on every downstream round-trip
+    private static final long   CANCEL_AFTER_MS  = 80;  // < BEGIN_LATENCY_MS, so cancel lands mid-BEGIN
+    private static final String APP_NAME         = "r2dbc-postgresql";
+
+    private static Network             network;
+    private static PostgreSQLContainer<?> postgres;
+    private static ToxiproxyContainer  toxiproxy;
+    private static ToxiproxyClient     toxiproxyClient;
+    private static Proxy               proxy;
+
+    // The jOOQ plain-SQL handles for table t(id int).
+    private static final Table<?>      T  = DSL.table(DSL.name("t"));
+    private static final Field<Integer> ID = DSL.field(DSL.name("id"), Integer.class);
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        network = Network.newNetwork();
+
+        postgres = new PostgreSQLContainer<>(POSTGRES_IMAGE)
+            .withNetwork(network)
+            .withNetworkAliases("postgres")
+            .withUsername("postgres")
+            .withPassword("postgres")
+            .withDatabaseName("postgres");
+        postgres.start();
+
+        toxiproxy = new ToxiproxyContainer(TOXIPROXY_IMAGE).withNetwork(network);
+        toxiproxy.start();
+
+        // One table to write into.
+        try (Connection c = directJdbc(); Statement s = c.createStatement()) {
+            s.execute("DROP TABLE IF EXISTS t");
+            s.execute("CREATE TABLE t (id int)");
+        }
+
+        // Point a proxy at postgres:5432 on the shared network. The pool will
+        // connect through toxiproxy's mapped 8666; the latency toxic is added
+        // per-test (after warmup) so it never affects connection establishment.
+        toxiproxyClient = new ToxiproxyClient(toxiproxy.getHost(), toxiproxy.getControlPort());
+        proxy = toxiproxyClient.createProxy("postgres", "0.0.0.0:" + TOXIPROXY_PROXY_PORT, "postgres:5432");
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        if (toxiproxy != null) toxiproxy.stop();
+        if (postgres != null)  postgres.stop();
+        if (network != null)   network.close();
+    }
+
+    // ---- the bug -----------------------------------------------------------
+
+    @Test
+    public void bug_cancelDuringBegin_leaksConnection() throws Exception {
+        ConnectionPool pool = newWarmPool();
+        try {
+            // Inject the BEGIN round-trip latency now, AFTER warmup, so the only
+            // thing slowed down is jOOQ's in-transaction round-trips.
+            Latency toxic = proxy.toxics().latency("begin-latency", ToxicDirection.DOWNSTREAM, BEGIN_LATENCY_MS);
+            try {
+                DSLContext dsl = DSL.using(pool, SQLDialect.POSTGRES);
+
+                for (int i = 0; i < N_TRANSACTIONS; i++) {
+                    Publisher<Integer> txn = dsl.transactionPublisher(cfg ->
+                        Flux.from(cfg.dsl().insertInto(T).columns(ID).values(1).returning(ID))
+                            .map(r -> r.get(ID)));
+
+                    // Subscribe, let BEGIN get in flight (it is delayed 300ms),
+                    // then cancel — Disposable.dispose() == Subscription.cancel().
+                    Disposable sub = Flux.from(txn).subscribe(x -> {}, err -> {});
+                    Thread.sleep(CANCEL_AFTER_MS);
+                    sub.dispose();
+                }
+
+                // Let any async release settle (real time, not a virtual clock).
+                Thread.sleep(2000);
+
+                int acquired = acquiredSize(pool);
+                System.out.println("[bug] acquiredSize after cancelled transactions = " + acquired
+                    + " (expected 0 if fixed; > 0 means leaked)");
+                printIdleInTransaction("bug");
+
+                assertTrue(
+                    "EXPECTED THE LEAK: transactionPublisher cancelled mid-BEGIN should leave "
+                        + "connections checked out. acquiredSize=" + acquired
+                        + ". If this is 0, jOOQ " + jooqVersion() + " has fixed the bug.",
+                    acquired > 0);
+            } finally {
+                toxic.remove();
+            }
+        } finally {
+            pool.close();
+        }
+    }
+
+    // ---- controls that must NOT leak ---------------------------------------
+
+    @Test
+    public void control_runToCompletion_doesNotLeak() throws Exception {
+        ConnectionPool pool = newWarmPool();
+        try {
+            DSLContext dsl = DSL.using(pool, SQLDialect.POSTGRES);
+
+            for (int i = 0; i < N_TRANSACTIONS; i++) {
+                Publisher<Integer> txn = dsl.transactionPublisher(cfg ->
+                    Flux.from(cfg.dsl().insertInto(T).columns(ID).values(1).returning(ID))
+                        .map(r -> r.get(ID)));
+                // Run to completion — no cancel.
+                Flux.from(txn).blockLast(Duration.ofSeconds(10));
+            }
+
+            Thread.sleep(1000);
+            int acquired = acquiredSize(pool);
+            System.out.println("[control:complete] acquiredSize = " + acquired + " (expected 0)");
+            assertEquals("Completed transactions must return every connection to the pool", 0, acquired);
+        } finally {
+            pool.close();
+        }
+    }
+
+    @Test
+    public void control_cancelDuringActiveStatement_doesNotLeak() throws Exception {
+        ConnectionPool pool = newWarmPool();
+        try {
+            // No latency toxic: BEGIN completes fast, then pg_sleep(3) is the
+            // active statement, and we cancel while IT is in flight — the window
+            // jOOQ already handles (ROLLBACK + close run).
+            DSLContext dsl = DSL.using(pool, SQLDialect.POSTGRES);
+
+            for (int i = 0; i < N_TRANSACTIONS; i++) {
+                Publisher<?> txn = dsl.transactionPublisher(cfg ->
+                    Flux.from(cfg.dsl().resultQuery("select pg_sleep(3)")));
+                Disposable sub = Flux.from(txn).subscribe(x -> {}, err -> {});
+                Thread.sleep(500); // BEGIN done; cancel lands inside pg_sleep
+                sub.dispose();
+            }
+
+            Thread.sleep(2000);
+            int acquired = acquiredSize(pool);
+            System.out.println("[control:active-stmt] acquiredSize = " + acquired + " (expected 0)");
+            printIdleInTransaction("control:active-stmt");
+            assertEquals(
+                "Cancelling during an active statement is handled by jOOQ (rollback + close)",
+                0, acquired);
+        } finally {
+            pool.close();
+        }
+    }
+
+    // ---- helpers -----------------------------------------------------------
+
+    private static ConnectionPool newWarmPool() {
+        PostgresqlConnectionConfiguration cfg = PostgresqlConnectionConfiguration.builder()
+            .host(toxiproxy.getHost())
+            .port(toxiproxy.getMappedPort(TOXIPROXY_PROXY_PORT))
+            .username(postgres.getUsername())
+            .password(postgres.getPassword())
+            .database(postgres.getDatabaseName())
+            .applicationName(APP_NAME)
+            .build();
+
+        ConnectionPoolConfiguration poolConfig = ConnectionPoolConfiguration.builder(new PostgresqlConnectionFactory(cfg))
+            .maxSize(POOL_SIZE)
+            .initialSize(POOL_SIZE)
+            .minIdle(POOL_SIZE)
+            // LOCAL == no round-trip on acquire, so the acquire itself never
+            // absorbs the cancel; jOOQ's first round-trip is the BEGIN.
+            .validationDepth(ValidationDepth.LOCAL)
+            .maxAcquireTime(Duration.ofSeconds(10))
+            .build();
+
+        ConnectionPool pool = new ConnectionPool(poolConfig);
+        // Establish all connections BEFORE any latency is introduced.
+        pool.warmup().block(Duration.ofSeconds(60));
+        return pool;
+    }
+
+    private static int acquiredSize(ConnectionPool pool) {
+        return pool.getMetrics()
+            .orElseThrow(() -> new IllegalStateException("pool metrics unavailable"))
+            .acquiredSize();
+    }
+
+    /** Corroborating evidence: sessions stuck mid-transaction, read on a side JDBC connection. */
+    private static void printIdleInTransaction(String label) throws SQLException {
+        try (Connection c = directJdbc(); Statement s = c.createStatement()) {
+            ResultSet rs = s.executeQuery(
+                "select count(*) as n, state, query from pg_stat_activity "
+                    + "where application_name = '" + APP_NAME + "' and state = 'idle in transaction' "
+                    + "group by state, query");
+            boolean any = false;
+            while (rs.next()) {
+                any = true;
+                System.out.printf("[%s] pg_stat_activity: %d session(s) state='%s' query='%s'%n",
+                    label, rs.getInt("n"), rs.getString("state"), rs.getString("query"));
+            }
+            if (!any) {
+                System.out.printf("[%s] pg_stat_activity: no 'idle in transaction' sessions%n", label);
+            }
+        }
+    }
+
+    /** Direct JDBC to Postgres (bypassing Toxiproxy) for setup and evidence queries. */
+    private static Connection directJdbc() throws SQLException {
+        return DriverManager.getConnection(
+            postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword());
+    }
+
+    private static String jooqVersion() {
+        String v = org.jooq.Constants.VERSION;
+        return v == null ? "(unknown)" : v;
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -34,3 +34,7 @@ include("jOOQ-mcve-kotlin-postgres")
 include("jOOQ-mcve-kotlin-sqlite")
 include("jOOQ-mcve-kotlin-sqlserver")
 include("jOOQ-mcve-scala-h2")
+
+// Reproducer for jOOQ #<issue>: transactionPublisher leaks an r2dbc connection
+// when its subscription is cancelled mid-BEGIN. See the module README.
+include("jOOQ-mcve-java-r2dbc-txn-leak")


### PR DESCRIPTION
flake.nix/.envrc/.gitignore: nix dev shell providing JDK 21 and Testcontainers/podman wiring (DOCKER_HOST -> podman socket, TESTCONTAINERS_RYUK_DISABLED), mirroring the utilityai setup trimmed to this project's needs.

jOOQ-mcve-java-r2dbc-txn-leak: reproducer for the jOOQ DSLContext.transactionPublisher(...) connection leak when the subscription is cancelled mid-BEGIN. Java + Reactor + Testcontainers (Postgres + Toxiproxy latency injection). Includes the two control cases and prints pg_stat_activity evidence. See the module README.

Note: the bug test asserts the buggy behaviour (acquiredSize > 0). As committed it does not reproduce on this repo's jOOQ 3.21.6 (nor, via this harness, on 3.21.1) — the harness needs further tuning of the cancellation window before it deterministically demonstrates the leak.